### PR TITLE
Set the 'resource class' for your circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ orbs:
 
 jobs:
   aws_configure:
+    resource_class: small
     parameters:
       profile:
         type: string
@@ -29,6 +30,7 @@ jobs:
       AWS_DEFAULT_REGION: eu-central-1
 
   terraform_plan:
+    resource_class: small
     parameters:
       plan_path:
         type: string
@@ -55,6 +57,7 @@ jobs:
       AWS_DEFAULT_REGION: eu-central-1
 
   terraform_apply:
+    resource_class: small
     parameters:
       deploy_path:
         type: string


### PR DESCRIPTION

This PR sets the `resource_class` for your circleci jobs:

As part of our strategy to optimize and reduce our CircleCI usage at Aviv, we want to ensure that all your jobs have the attribute `resource_class` specified.

Read our announcement here: https://kugawana.slack.com/archives/C03U9RFSFBP/p1720517660099979

If you encounter any issues or have questions, please reach out to us on Slack (`#aviv_devops_tooling`).

---
This PR has been generated by [Platform CircleCI Tooling](https://github.com/axel-springer-kugawana/aviv_platform_circleci-tooling).
